### PR TITLE
Fix Deployment Errors

### DIFF
--- a/src/routes/translate/translateRoutes.ts
+++ b/src/routes/translate/translateRoutes.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 
-import { translator } from '../../google_APIs/clients';
+import { translator } from '../../google_apis/clients';
 import { authorize, validateReqBody } from '../../middleware';
 
 const router = Router();

--- a/src/routes/vision/visionRoutes.ts
+++ b/src/routes/vision/visionRoutes.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import Joi from 'joi';
 
-import { annotator, translator } from '../../google_APIs/clients';
+import { annotator, translator } from '../../google_apis/clients';
 import { authorize, validateReqBody } from '../../middleware';
 import { LANGCODE_ENGLISH } from '../../helpers/constants';
 


### PR DESCRIPTION
Some import paths were capitalized. VS Code forgave this, but Heroku's environment is pickier.